### PR TITLE
Fix Visualization for SageMaker Studio Demo

### DIFF
--- a/src/sagemaker_defect_detection/utils/visualize.py
+++ b/src/sagemaker_defect_detection/utils/visualize.py
@@ -150,4 +150,5 @@ def visualize(
             img = visualize_bbox(img, bbox, class_name, color=colors[j])
 
         plt.imshow(img)
+        plt.show()
     return


### PR DESCRIPTION
Hi Ehsan,

I've been trying to run the Product Defect Detection solution demo in SageMaker Studio, but was very confused because the visualize function/section in the **0_demo.ipynb** Jupyter notebook didn't seem to do anything. After some digging, I finally found the issue! Calling **matplotlib.pyplot**'s `plt.imshow()` in this environment doesn't display the visualization, it just finishes drawing (see [here](https://stackoverflow.com/questions/42812230/why-plt-imshow-doesnt-display-the-image)). To actually display the image we need to call `plt.show()`.
